### PR TITLE
AD-217886: Add two new JCP options to SignpostedToCategory

### DIFF
--- a/DFC.App.ActionPlans.Services.DSS/Enums/SignpostedToCategory.cs
+++ b/DFC.App.ActionPlans.Services.DSS/Enums/SignpostedToCategory.cs
@@ -19,6 +19,11 @@ namespace DFC.App.ActionPlans.Services.DSS.Enums
         SpecialistOrganisation = 7,
         [Display(Name = "JCP")] JCP = 8,
         [Display(Name = "Employer")] Employer = 9,
+        [Display(Name = "Job Centre Plus WITH Data")]
+        JCPWithData = 14,
+        
+        [Display(Name = "Job Centre Plus WITHOUT Data")]
+        JCPWithoutData = 15,
         [Display(Name = "Other")] Other = 99
     }
 }

--- a/DFC.App.ActionPlans.Services.DSS/Enums/SignpostedToCategory.cs
+++ b/DFC.App.ActionPlans.Services.DSS/Enums/SignpostedToCategory.cs
@@ -4,26 +4,40 @@ namespace DFC.App.ActionPlans.Services.DSS.Enums
 {
     public enum SignpostedToCategory
     {
-        [Display(Name = "Charity National")] CharityNational = 1,
-        [Display(Name = "Charity Local")] CharityLocal = 2,
-        [Display(Name = "Training Provider")] TrainingProvider = 3,
-        [Display(Name = "College")] College = 4,
+        [Display(Name = "Charity")]
+        Charity = 1,
 
-        [Display(Name = "National Retraining Scheme")]
-        NationalRetrainingScheme = 5,
+        [Display(Name = "Training Provider")]
+        TrainingProvider = 3,
 
-        [Display(Name = "Apprenticeship Service")]
+        [Display(Name = "Apprenticeships")]
         ApprenticeshipService = 6,
 
         [Display(Name = "Specialist Organisation")]
         SpecialistOrganisation = 7,
-        [Display(Name = "JCP")] JCP = 8,
-        [Display(Name = "Employer")] Employer = 9,
+
+        JCP = 8,
+
+        Employer = 9,
+
+        [Display(Name = "Traineeships")]
+        Traineeships = 10,
+
+        [Display(Name = "Further Education")]
+        FurtherEducation = 11,
+
+        [Display(Name = "Higher Education")]
+        HigherEducation = 12,
+
+        [Display(Name = "Community Centres")]
+        CommunityCentres = 13,
+        
         [Display(Name = "Job Centre Plus WITH Data")]
         JCPWithData = 14,
         
         [Display(Name = "Job Centre Plus WITHOUT Data")]
         JCPWithoutData = 15,
-        [Display(Name = "Other")] Other = 99
+
+        Other = 99
     }
 }


### PR DESCRIPTION
Following what the code currently supports (https://github.com/SkillsFundingAgency/dss-actions/blob/master/NCS.DSS.Action/ReferenceData/SignpostedToCategory.cs):

- Rename option 1 - "Charity - National" to "Charity"
- Remove option 2 - "Charity - Local"
- Add option 10 - "Traineeships"
- Add option 11 - "Further Education"
- Add option 12 - "Higher Education"
- Add option 13 - "Community Centres"
- Add option 14 - "Job Centre Plus WITH Data"
- Add option 15 - "Job Centre Plus WITHOUT Data"